### PR TITLE
Add option to load in-memory certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Here's a snippet demonstrating how this library is meant to be used:
 func httpClient() (*http.Client, error)
 	tlsConfig := &tls.Config{}
 	err := rootcerts.ConfigureTLS(tlsConfig, &rootcerts.Config{
-		CAFile: os.Getenv("MYAPP_CAFILE"),
-		CAPath: os.Getenv("MYAPP_CAPATH"),
+		CAFile:      os.Getenv("MYAPP_CAFILE"),
+		CAPath:      os.Getenv("MYAPP_CAPATH"),
+        Certificate: os.Getenv("MYAPP_CERTIFICATE"),
 	})
 	if err != nil {
 		return nil, err

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ func httpClient() (*http.Client, error)
 	err := rootcerts.ConfigureTLS(tlsConfig, &rootcerts.Config{
 		CAFile:      os.Getenv("MYAPP_CAFILE"),
 		CAPath:      os.Getenv("MYAPP_CAPATH"),
-        Certificate: os.Getenv("MYAPP_CERTIFICATE"),
+		Certificate: os.Getenv("MYAPP_CERTIFICATE"),
 	})
 	if err != nil {
 		return nil, err

--- a/rootcerts_test.go
+++ b/rootcerts_test.go
@@ -1,6 +1,7 @@
 package rootcerts
 
 import (
+	"io/ioutil"
 	"path/filepath"
 	"testing"
 )
@@ -24,6 +25,18 @@ func TestLoadCACertsHandlesNil(t *testing.T) {
 func TestLoadCACertsFromFile(t *testing.T) {
 	path := testFixture("cafile", "cacert.pem")
 	_, err := LoadCACerts(&Config{CAFile: path})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestLoadCACertsInMem(t *testing.T) {
+	path := testFixture("cafile", "cacert.pem")
+	pem, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("err : %s", err)
+	}
+	_, err = LoadCACerts(&Config{Certificate: string(pem[:])})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/rootcerts_test.go
+++ b/rootcerts_test.go
@@ -1,12 +1,16 @@
 package rootcerts
 
 import (
+	"crypto/sha256"
+	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
 )
 
 const fixturesDir = "./test-fixtures"
+const caCertSHA256Sum = "e85d9f94f730878cc1a516d9486fdb0255452b37961f325af9fc851cc4689311"
 
 func TestConfigureTLSHandlesNil(t *testing.T) {
 	err := ConfigureTLS(nil, nil)
@@ -24,10 +28,11 @@ func TestLoadCACertsHandlesNil(t *testing.T) {
 
 func TestLoadCACertsFromFile(t *testing.T) {
 	path := testFixture("cafile", "cacert.pem")
-	_, err := LoadCACerts(&Config{CAFile: path})
+	p, err := LoadCACerts(&Config{CAFile: path})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	testCertLoaded(t, p)
 }
 
 func TestLoadCACertsInMem(t *testing.T) {
@@ -36,30 +41,54 @@ func TestLoadCACertsInMem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err : %s", err)
 	}
-	_, err = LoadCACerts(&Config{CACertificate: pem})
+	p, err := LoadCACerts(&Config{CACertificate: pem})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	testCertLoaded(t, p)
 }
 
 func TestLoadCACertsFromDir(t *testing.T) {
 	path := testFixture("capath")
-	_, err := LoadCACerts(&Config{CAPath: path})
+	p, err := LoadCACerts(&Config{CAPath: path})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	testCertLoaded(t, p)
 }
 
 func TestLoadCACertsFromDirWithSymlinks(t *testing.T) {
 	path := testFixture("capath-with-symlinks")
-	_, err := LoadCACerts(&Config{CAPath: path})
+	p, err := LoadCACerts(&Config{CAPath: path})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	testCertLoaded(t, p)
 }
 
 func testFixture(n ...string) string {
 	parts := []string{fixturesDir}
 	parts = append(parts, n...)
 	return filepath.Join(parts...)
+}
+
+func testCertLoaded(t *testing.T, p *x509.CertPool) {
+	switch len(p.Subjects()) {
+	case 0:
+		t.Fatal("expected a certificate in the pool")
+	case 1:
+		h := sha256.New()
+		h.Write(p.Subjects()[0])
+		sha256Sum := fmt.Sprintf("%x", h.Sum(nil))
+		if caCertSHA256Sum != sha256Sum {
+			t.Fatalf("sha256 sum mismatch; got '%x'; expected '%s'", sha256Sum, caCertSHA256Sum)
+		}
+	default:
+		// Check if length is not zero
+		for _, subj := range p.Subjects() {
+			if len(subj) == 0 {
+				t.Fatal("expected certificate with data included")
+			}
+		}
+	}
 }

--- a/rootcerts_test.go
+++ b/rootcerts_test.go
@@ -36,7 +36,7 @@ func TestLoadCACertsInMem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err : %s", err)
 	}
-	_, err = LoadCACerts(&Config{Certificate: string(pem[:])})
+	_, err = LoadCACerts(&Config{CACertificate: pem})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
This PR adds the option to load a certificate that is already in-memory and does not to be read from disk. This should allow us to define the Server TLS certificate for a running Nomad server when using the Nomad API SDK.

Related Issue: https://github.com/hashicorp/vault/issues/5619 