### PR TITLE
Allow specifying a *x509.CertPool in Config

### DIFF
--- a/rootcerts.go
+++ b/rootcerts.go
@@ -11,13 +11,17 @@ import (
 )
 
 // Config determines where LoadCACerts will load certificates from. When CAFile,
-// CACertificate and CAPath are blank, this library's functions will either load
-// system roots explicitly and return them, or set the CertPool to nil to allow
-// Go's standard library to load system certs.
+// CACertPool, CACertificate and CAPath are blank, this library's functions will
+// either load system roots explicitly and return them, or set the CertPool to nil
+// to allow Go's standard library to load system certs.
 type Config struct {
 	// CAFile is a path to a PEM-encoded certificate file or bundle. Takes
 	// precedence over CACertificate and CAPath.
 	CAFile string
+
+	// CACertPool is a set of certificates. Takes precedence over CACertificate
+	// and CAPath.
+	CACertPool *x509.CertPool
 
 	// CACertificate is a PEM-encoded certificate or bundle. Takes precedence
 	// over CAPath.
@@ -48,6 +52,9 @@ func LoadCACerts(c *Config) (*x509.CertPool, error) {
 	}
 	if c.CAFile != "" {
 		return LoadCAFile(c.CAFile)
+	}
+	if c.CACertPool != nil {
+		return c.CACertPool, nil
 	}
 	if len(c.CACertificate) != 0 {
 		return AppendCertificate(c.CACertificate)

--- a/rootcerts_test.go
+++ b/rootcerts_test.go
@@ -48,6 +48,23 @@ func TestLoadCACertsInMem(t *testing.T) {
 	testCertLoaded(t, p)
 }
 
+func TestLoadCACertsFromCertPool(t *testing.T) {
+	path := testFixture("cafile", "cacert.pem")
+	pem, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("err : %s", err)
+	}
+
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(pem)
+
+	p, err := LoadCACerts(&Config{CACertPool: certPool})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	testCertLoaded(t, p)
+}
+
 func TestLoadCACertsFromDir(t *testing.T) {
 	path := testFixture("capath")
 	p, err := LoadCACerts(&Config{CAPath: path})


### PR DESCRIPTION
Some packages like `github.com/certifi/gocertifi` only allow retrieving a `*x509.CertPool` with a list of root certificates, and you can't extract the actual certificates in PEM/DER form from it.

And since Vault's `TLSConfig` mimicks the `go-rootcerts` `Config` structure (https://github.com/hashicorp/vault/blob/06c0c6c8820669f6b70eb8e065ac6d2faf9dae20/api/client.go#L194-L220) and uses `go-rootcerts` for TLS structure configuration, it makes sense to support passing `*x509.CertPool` here first, and then add the corresponding field to `Vault`'s `TLSConfig`.

Here's a real-world example of when this is useful: https://github.com/cirruslabs/cirrus-ci-agent/pull/255.