### PR TITLE
Use os.UserHomeDir() (darwin) and drop dependency on go-homedir (all)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/hashicorp/go-rootcerts
 
 go 1.12
-
-require github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/rootcerts_darwin.go
+++ b/rootcerts_darwin.go
@@ -2,10 +2,9 @@ package rootcerts
 
 import (
 	"crypto/x509"
+	"os"
 	"os/exec"
 	"path"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 // LoadSystemCAs has special behavior on Darwin systems to work around
@@ -39,8 +38,8 @@ func certKeychains() []string {
 		"/System/Library/Keychains/SystemRootCertificates.keychain",
 		"/Library/Keychains/System.keychain",
 	}
-	home, err := homedir.Dir()
-	if err == nil {
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
 		loginKeychain := path.Join(home, "Library", "Keychains", "login.keychain")
 		keychains = append(keychains, loginKeychain)
 	}


### PR DESCRIPTION
Note: This change applies to code compiled only for darwin, but it also allows to remove a dependency from go.mod which will ease maintenance of downstream projects for any platforms.

Use [`os.UserHomeDir()`](https://pkg.go.dev/os#UserHomeDir) which is available since go1.12 (already the minimum go version for this project). This allows to drop the dependency on [`github.com/mitchellh/go-homedir`](https://pkg.go.dev/github.com/mitchellh/go-homedir) which was needed only for Darwin.

[`go-homedir`](https://pkg.go.dev/github.com/mitchellh/go-homedir) still has the following features on Darwin:
* tries very hard to get the location of the home directory when $HOME is not set
* avoids use of [`os/user`](https://pkg.go.dev/os/user) which dependended on cgo until go1.20

I don't think we really need to go beyond `$HOME`. However if we really wanted it we could now use [`os/user.Current()`](https://pkg.go.dev/os/user#Current) as since go1.20 it uses the libc on Darwin and no longer needs cgo on any platform. So we should drop `go-homedir` anyway.