### PR TITLE
Update CODEOWNERS to @hashicorp/team-consul-core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Default owner
-* @hashicorp/consul
+* @hashicorp/team-consul-core
 
 # Add override rules below. Each line is a file/folder pattern followed by one or more owners.
 # Being an owner means those groups or individuals will be added as reviewers to PRs affecting


### PR DESCRIPTION
Updates the default code owner from `@hashicorp/consul` to `@hashicorp/team-consul-core` for all files.